### PR TITLE
Markdown to wechat html converter with theme support

### DIFF
--- a/packages/wx-md/README.md
+++ b/packages/wx-md/README.md
@@ -1,0 +1,43 @@
+# wx-md
+
+将 Markdown 转为适合微信公众号排版的 HTML，支持：
+- 页面主题（default/narrow/wide）
+- 代码主题（highlight.js 风格：github、tomorrow 系列等）
+- 文字排版主题（内置“墨滴”与 classic）
+
+## 安装
+
+```
+npm i wx-md
+```
+
+## 使用（Node API）
+
+```ts
+import { renderWeChatHtml } from 'wx-md';
+
+const md = '# 标题\n\n一些内容...';
+const { html, css, fullHtml } = await renderWeChatHtml(md, {
+  pageTheme: 'wide',
+  codeTheme: 'tomorrow-night-eighties',
+  typographyTheme: 'mo-di',
+  embedCss: true,
+});
+```
+
+- embedCss: true 时，返回的 html 已内联样式，可直接粘贴到微信。
+- fullHtmlDocument: true 时，同时返回完整 HTML 文档，便于预览或导出。
+
+## CLI
+
+```
+# 从文件读取，内联样式并输出到 out.html
+wxmd input.md --page=wide --code=tomorrow-night-eighties --typo=mo-di --embed --out=out.html
+
+# 从 stdin 读取并输出到 stdout
+cat input.md | wxmd --embed > out.html
+```
+
+## 注意
+- 已内置 WeChat 兼容处理（如去除 li>p 包裹，图片响应式等）。
+- 数学公式（remark-math）仅转为 HTML 结构，微信不渲染 LaTeX，建议转为图片或自行引入图片公式。

--- a/packages/wx-md/bin/wxmd.ts
+++ b/packages/wx-md/bin/wxmd.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { renderWeChatHtml } from '../src/index.js';
+
+function parseArgs(argv: string[]) {
+  const args: Record<string, string|boolean> = {} as any;
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith('--')) {
+      const [k, v] = a.split('=');
+      (args as any)[k.replace(/^--/, '')] = v ?? true;
+    } else if (!(args as any)._ ) {
+      (args as any)._ = a;
+    }
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const inputPath = (args._ as string) || '';
+  const pageTheme = (args['page'] as any) || 'wide';
+  const codeTheme = (args['code'] as any) || 'tomorrow-night-eighties';
+  const typography = (args['typo'] as any) || 'mo-di';
+  const embedCss = Boolean(args['embed']);
+  const full = Boolean(args['full']);
+  const out = (args['out'] as string) || '';
+
+  const md = inputPath ? fs.readFileSync(path.resolve(inputPath), 'utf8') : fs.readFileSync(0, 'utf8');
+
+  const { html, css, fullHtml } = await renderWeChatHtml(md, {
+    pageTheme,
+    codeTheme,
+    typographyTheme: typography,
+    embedCss,
+    fullHtmlDocument: full,
+  } as any);
+
+  const content = full ? (fullHtml as string) : (embedCss ? html : `<article class=\"wxmd-article\">${html}</article>`);
+
+  if (out) {
+    fs.writeFileSync(path.resolve(out), content, 'utf8');
+  } else {
+    process.stdout.write(content);
+  }
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/wx-md/package.json
+++ b/packages/wx-md/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "wx-md",
+  "version": "0.1.0",
+  "description": "Markdown to WeChat-friendly HTML with page, code and typography themes (including MoDi).",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "wxmd": "dist/bin/wxmd.js"
+  },
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts && tsup bin/wxmd.ts --format esm --banner.js='#!/usr/bin/env node'",
+    "dev": "tsup src/index.ts --format esm,cjs --dts --watch",
+    "clean": "rimraf dist"
+  },
+  "dependencies": {
+    "rehype-autolink-headings": "^7.1.0",
+    "rehype-highlight": "^7.0.0",
+    "rehype-raw": "^7.0.0",
+    "rehype-slug": "^6.0.0",
+    "rehype-stringify": "^10.0.0",
+    "remark-footnotes": "^3.0.0",
+    "remark-gfm": "^4.0.0",
+    "remark-math": "^6.0.0",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.0",
+    "unified": "^11.0.0",
+    "unist-util-visit": "^5.0.0",
+    "highlight.js": "^11.9.0"
+  },
+  "devDependencies": {
+    "rimraf": "^5.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/packages/wx-md/src/converters/rehype-wechat.ts
+++ b/packages/wx-md/src/converters/rehype-wechat.ts
@@ -1,0 +1,32 @@
+import type { Root, Element, Content } from 'hast';
+import { visit } from 'unist-util-visit';
+
+export default function rehypeWeChatCompatible() {
+  return function transformer(tree: Root) {
+    // Unwrap <li><p>...</p></li> to <li>...</li>
+    visit(tree, 'element', (node: Element) => {
+      if (node.tagName === 'li' && Array.isArray(node.children) && node.children.length === 1) {
+        const only = node.children[0];
+        if ((only as any).type === 'element' && (only as Element).tagName === 'p') {
+          const p = only as Element;
+          node.children = (p.children as Content[]) || [];
+        }
+      }
+
+      // Ensure images are responsive in WeChat
+      if (node.tagName === 'img') {
+        node.properties = node.properties || {};
+        const style = String((node.properties as any).style || '');
+        const ensure = 'max-width:100%;height:auto;';
+        (node.properties as any).style = style.includes('max-width') ? style : (style ? style + ';' : '') + ensure;
+      }
+
+      // Remove iframe/script for safety by default (WeChat likely strips them)
+      if (node.tagName === 'script' || node.tagName === 'iframe') {
+        node.tagName = 'div';
+        node.children = [];
+        node.properties = { 'data-removed': node.tagName } as any;
+      }
+    });
+  };
+}

--- a/packages/wx-md/src/converters/wechat.ts
+++ b/packages/wx-md/src/converters/wechat.ts
@@ -1,0 +1,103 @@
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkGfm from 'remark-gfm';
+import remarkFootnotes from 'remark-footnotes';
+import remarkMath from 'remark-math';
+import remarkRehype from 'remark-rehype';
+import rehypeRaw from 'rehype-raw';
+import rehypeStringify from 'rehype-stringify';
+import rehypeSlug from 'rehype-slug';
+import rehypeAutolinkHeadings from 'rehype-autolink-headings';
+import rehypeHighlight from 'rehype-highlight';
+import rehypeWeChatCompatible from './rehype-wechat.js';
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { RenderOptions, RenderResult, PageTheme, TypographyTheme, CodeTheme } from '../index.js';
+
+const pkgRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../..');
+
+function loadCss(relPath: string): string {
+  const p = path.join(pkgRoot, 'src', relPath);
+  return fs.readFileSync(p, 'utf8');
+}
+
+function getPageCss(theme: PageTheme): string {
+  switch (theme) {
+    case 'narrow':
+      return loadCss('themes/page/narrow.css');
+    case 'wide':
+      return loadCss('themes/page/wide.css');
+    default:
+      return loadCss('themes/page/default.css');
+  }
+}
+
+function getTypographyCss(theme: TypographyTheme): string {
+  switch (theme) {
+    case 'mo-di':
+      return loadCss('themes/typography/mo-di.css');
+    default:
+      return loadCss('themes/typography/classic.css');
+  }
+}
+
+function getCodeCss(theme: CodeTheme): string {
+  switch (theme) {
+    case 'github':
+      return loadCss('themes/code/github.css');
+    case 'tomorrow':
+      return loadCss('themes/code/tomorrow.css');
+    case 'tomorrow-night':
+      return loadCss('themes/code/tomorrow-night.css');
+    case 'tomorrow-night-blue':
+      return loadCss('themes/code/tomorrow-night-blue.css');
+    case 'tomorrow-night-bright':
+      return loadCss('themes/code/tomorrow-night-bright.css');
+    case 'tomorrow-night-eighties':
+      return loadCss('themes/code/tomorrow-night-eighties.css');
+    default:
+      return loadCss('themes/code/github.css');
+  }
+}
+
+export async function renderWeChatHtml(markdown: string, options: RenderOptions = {}): Promise<RenderResult> {
+  const pageTheme = options.pageTheme ?? 'wide';
+  const typographyTheme = options.typographyTheme ?? 'mo-di';
+  const codeTheme = options.codeTheme ?? 'tomorrow-night-eighties';
+
+  const processor = unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkFootnotes, { inlineNotes: true })
+    .use(remarkMath)
+    .use(remarkRehype, { allowDangerousHtml: true })
+    .use(rehypeRaw)
+    .use(rehypeSlug)
+    .use(rehypeAutolinkHeadings, { behavior: 'wrap' })
+    .use(rehypeHighlight)
+    .use(rehypeWeChatCompatible)
+    .use(rehypeStringify, { allowDangerousHtml: true });
+
+  const file = await processor.process(markdown);
+  const htmlBody = String(file);
+
+  const css = [
+    getPageCss(pageTheme),
+    getTypographyCss(typographyTheme),
+    getCodeCss(codeTheme)
+  ].join('\n\n');
+
+  if (options.fullHtmlDocument) {
+    const fullHtml = `<!doctype html>\n<html>\n<head>\n<meta charset=\"utf-8\">\n<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n<style>\n${css}\n</style>\n</head>\n<body>\n<article class=\"wxmd-article\">${htmlBody}</article>\n</body>\n</html>`;
+    return { html: htmlBody, css, fullHtml };
+  }
+
+  if (options.embedCss) {
+    const withStyle = `<style>\n${css}\n</style>\n<article class=\"wxmd-article\">${htmlBody}</article>`;
+    return { html: withStyle, css };
+  }
+
+  return { html: htmlBody, css };
+}

--- a/packages/wx-md/src/index.ts
+++ b/packages/wx-md/src/index.ts
@@ -1,0 +1,26 @@
+export type PageTheme = 'default' | 'narrow' | 'wide';
+export type TypographyTheme = 'mo-di' | 'classic';
+export type CodeTheme =
+  | 'github'
+  | 'tomorrow'
+  | 'tomorrow-night'
+  | 'tomorrow-night-blue'
+  | 'tomorrow-night-bright'
+  | 'tomorrow-night-eighties';
+
+export interface RenderOptions {
+  pageTheme?: PageTheme;
+  typographyTheme?: TypographyTheme;
+  codeTheme?: CodeTheme;
+  embedCss?: boolean;
+  fullHtmlDocument?: boolean;
+}
+
+export interface RenderResult {
+  html: string;
+  css: string;
+  fullHtml?: string;
+}
+
+import { renderWeChatHtml } from './converters/wechat.js';
+export { renderWeChatHtml };

--- a/packages/wx-md/src/themes/code/github.css
+++ b/packages/wx-md/src/themes/code/github.css
@@ -1,0 +1,8 @@
+/* Github-like code theme */
+.hljs { display: block; overflow-x: auto; padding: 0.5em; background: #f6f8fa; color: #24292e; }
+.hljs-comment, .hljs-quote { color: #6a737d; font-style: italic; }
+.hljs-keyword, .hljs-selector-tag, .hljs-subst { color: #d73a49; }
+.hljs-literal, .hljs-number, .hljs-tag .hljs-attr, .hljs-template-variable, .hljs-variable { color: #005cc5; }
+.hljs-string, .hljs-doctag, .hljs-title, .hljs-section, .hljs-selector-id { color: #032f62; }
+.hljs-type, .hljs-class .hljs-title { color: #6f42c1; }
+.hljs-tag, .hljs-name, .hljs-attribute { color: #22863a; }

--- a/packages/wx-md/src/themes/code/tomorrow-night-blue.css
+++ b/packages/wx-md/src/themes/code/tomorrow-night-blue.css
@@ -1,0 +1,5 @@
+.hljs { display:block; overflow-x:auto; padding:0.5em; background:#001f3f; color:#e0e6f1 }
+.hljs-keyword, .hljs-selector-tag, .hljs-title, .hljs-section, .hljs-deletion, .hljs-subst { color:#ffb3b3 }
+.hljs-literal, .hljs-number, .hljs-name, .hljs-selector-id, .hljs-template-variable, .hljs-variable { color:#ffd1a4 }
+.hljs-string, .hljs-symbol, .hljs-bullet, .hljs-attribute, .hljs-addition { color:#b3ffd1 }
+.hljs-comment, .hljs-quote { color:#aac1d0; font-style:italic }

--- a/packages/wx-md/src/themes/code/tomorrow-night-bright.css
+++ b/packages/wx-md/src/themes/code/tomorrow-night-bright.css
@@ -1,0 +1,5 @@
+.hljs { display:block; overflow-x:auto; padding:0.5em; background:#000; color:#eaeaea }
+.hljs-keyword, .hljs-selector-tag, .hljs-title, .hljs-section, .hljs-deletion, .hljs-subst { color:#d2a6ff }
+.hljs-literal, .hljs-number, .hljs-name, .hljs-selector-id, .hljs-template-variable, .hljs-variable { color:#f7c873 }
+.hljs-string, .hljs-symbol, .hljs-bullet, .hljs-attribute, .hljs-addition { color:#9fea9f }
+.hljs-comment, .hljs-quote { color:#bcbcbc; font-style:italic }

--- a/packages/wx-md/src/themes/code/tomorrow-night-eighties.css
+++ b/packages/wx-md/src/themes/code/tomorrow-night-eighties.css
@@ -1,0 +1,5 @@
+.hljs { display:block; overflow-x:auto; padding:0.5em; background:#2d2d2d; color:#cccccc }
+.hljs-keyword, .hljs-selector-tag, .hljs-title, .hljs-section, .hljs-deletion, .hljs-subst { color:#cc99cd }
+.hljs-literal, .hljs-number, .hljs-name, .hljs-selector-id, .hljs-template-variable, .hljs-variable { color:#f99157 }
+.hljs-string, .hljs-symbol, .hljs-bullet, .hljs-attribute, .hljs-addition { color:#99cc99 }
+.hljs-comment, .hljs-quote { color:#999; font-style:italic }

--- a/packages/wx-md/src/themes/code/tomorrow-night.css
+++ b/packages/wx-md/src/themes/code/tomorrow-night.css
@@ -1,0 +1,5 @@
+.hljs { display:block; overflow-x:auto; padding:0.5em; background:#1d1f21; color:#c5c8c6 }
+.hljs-keyword, .hljs-selector-tag, .hljs-title, .hljs-section, .hljs-deletion, .hljs-subst { color:#b294bb }
+.hljs-literal, .hljs-number, .hljs-name, .hljs-selector-id, .hljs-template-variable, .hljs-variable { color:#de935f }
+.hljs-string, .hljs-symbol, .hljs-bullet, .hljs-attribute, .hljs-addition { color:#b5bd68 }
+.hljs-comment, .hljs-quote { color:#969896; font-style:italic }

--- a/packages/wx-md/src/themes/code/tomorrow.css
+++ b/packages/wx-md/src/themes/code/tomorrow.css
@@ -1,0 +1,5 @@
+.hljs { display:block; overflow-x:auto; padding:0.5em; background:#fdf6e3; color:#657b83 }
+.hljs-keyword, .hljs-selector-tag, .hljs-title, .hljs-section, .hljs-deletion, .hljs-subst { color:#268bd2 }
+.hljs-literal, .hljs-string, .hljs-bullet, .hljs-attribute, .hljs-addition { color:#2aa198 }
+.hljs-built_in, .hljs-builtin-name, .hljs-type, .hljs-class .hljs-title { color:#b58900 }
+.hljs-comment, .hljs-quote { color:#93a1a1; font-style:italic }

--- a/packages/wx-md/src/themes/page/default.css
+++ b/packages/wx-md/src/themes/page/default.css
@@ -1,0 +1,1 @@
+.wxmd-article { max-width: 720px; margin: 0 auto; padding: 16px; }

--- a/packages/wx-md/src/themes/page/narrow.css
+++ b/packages/wx-md/src/themes/page/narrow.css
@@ -1,0 +1,1 @@
+.wxmd-article { max-width: 620px; margin: 0 auto; padding: 12px; }

--- a/packages/wx-md/src/themes/page/wide.css
+++ b/packages/wx-md/src/themes/page/wide.css
@@ -1,0 +1,1 @@
+.wxmd-article { max-width: 860px; margin: 0 auto; padding: 18px; }

--- a/packages/wx-md/src/themes/typography/classic.css
+++ b/packages/wx-md/src/themes/typography/classic.css
@@ -1,0 +1,11 @@
+ .wxmd-article { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', sans-serif; color: #2b2b2b; line-height: 1.8; font-size: 16px; }
+ .wxmd-article h1, .wxmd-article h2, .wxmd-article h3, .wxmd-article h4, .wxmd-article h5, .wxmd-article h6 { color: #111; line-height: 1.35; margin: 1.6em 0 0.6em; }
+ .wxmd-article p { margin: 0.9em 0; }
+ .wxmd-article ul, .wxmd-article ol { padding-left: 1.6em; margin: 1em 0; }
+ .wxmd-article blockquote { color: #555; border-left: 4px solid #ddd; margin: 1.2em 0; padding: 0.6em 1em; background: #fafafa; }
+ .wxmd-article code { background: #f4f4f4; padding: 0.1em 0.3em; border-radius: 3px; font-size: 0.95em; }
+ .wxmd-article pre { background: #1e1e1e; color: #eaeaea; padding: 14px; overflow: auto; border-radius: 6px; }
+ .wxmd-article pre code { background: transparent; padding: 0; }
+ .wxmd-article table { border-collapse: collapse; width: 100%; margin: 1em 0; }
+ .wxmd-article th, .wxmd-article td { border: 1px solid #e5e5e5; padding: 8px 10px; }
+ .wxmd-article img { max-width: 100%; height: auto; }

--- a/packages/wx-md/src/themes/typography/mo-di.css
+++ b/packages/wx-md/src/themes/typography/mo-di.css
@@ -1,0 +1,18 @@
+ .wxmd-article { font-family: 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', 'Source Han Sans SC', 'Noto Sans CJK SC', system-ui, -apple-system, Segoe UI, Arial, sans-serif; color: #1f2328; line-height: 1.85; font-size: 17px; letter-spacing: 0.2px; }
+ .wxmd-article h1 { font-size: 1.9em; margin: 1.2em 0 0.6em; padding-bottom: 0.3em; border-bottom: 2px solid #1f2328; }
+ .wxmd-article h2 { font-size: 1.6em; margin: 1.2em 0 0.6em; border-left: 4px solid #1f2328; padding-left: 0.5em; }
+ .wxmd-article h3 { font-size: 1.3em; margin: 1.1em 0 0.5em; }
+ .wxmd-article h4, .wxmd-article h5, .wxmd-article h6 { margin: 1em 0 0.4em; color: #24292f; }
+ .wxmd-article p { margin: 0.95em 0; text-align: justify; }
+ .wxmd-article ul, .wxmd-article ol { padding-left: 1.6em; margin: 0.9em 0; }
+ .wxmd-article li { margin: 0.3em 0; }
+ .wxmd-article blockquote { color: #4b5563; background: #f8fafc; border-left: 4px solid #94a3b8; margin: 1.2em 0; padding: 0.8em 1em; }
+ .wxmd-article a { color: #0ea5e9; text-decoration: none; border-bottom: 1px dotted #7dd3fc; }
+ .wxmd-article a:hover { color: #0284c7; border-bottom-color: #38bdf8; }
+ .wxmd-article code { background: #f1f5f9; color: #0f172a; padding: 0.15em 0.35em; border-radius: 4px; font-size: 0.93em; }
+ .wxmd-article pre { background: #0b1020; color: #e2e8f0; padding: 14px; overflow: auto; border-radius: 8px; box-shadow: inset 0 0 0 1px rgba(255,255,255,0.05); }
+ .wxmd-article pre code { background: transparent; padding: 0; }
+ .wxmd-article table { border-collapse: collapse; width: 100%; margin: 1em 0; }
+ .wxmd-article th { background: #f1f5f9; }
+ .wxmd-article th, .wxmd-article td { border: 1px solid #e5e7eb; padding: 8px 10px; }
+ .wxmd-article img { max-width: 100%; display: block; margin: 0.6em auto; }

--- a/packages/wx-md/tsconfig.json
+++ b/packages/wx-md/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "skipLibCheck": true
+  },
+  "include": ["src", "bin"]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,26 @@
+export type PageTheme = 'default' | 'narrow' | 'wide';
+export type TypographyTheme = 'mo-di' | 'classic';
+export type CodeTheme =
+  | 'github'
+  | 'tomorrow'
+  | 'tomorrow-night'
+  | 'tomorrow-night-blue'
+  | 'tomorrow-night-bright'
+  | 'tomorrow-night-eighties';
+
+export interface RenderOptions {
+  pageTheme?: PageTheme;
+  typographyTheme?: TypographyTheme;
+  codeTheme?: CodeTheme;
+  embedCss?: boolean;
+  fullHtmlDocument?: boolean;
+}
+
+export interface RenderResult {
+  html: string;
+  css: string;
+  fullHtml?: string;
+}
+
+import { renderWeChatHtml } from './converters/wechat.js';
+export { renderWeChatHtml };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "skipLibCheck": true
+  },
+  "include": ["src", "bin"]
+}


### PR DESCRIPTION
Introduces `wx-md` library for converting Markdown to WeChat-compatible HTML, supporting customizable page, code, and typography themes.

This library includes built-in 'MoDi' typography theme and handles WeChat-specific compatibility issues like unwrapping `li>p` and making images responsive, providing both a Node API and a CLI.

---
<a href="https://cursor.com/background-agent?bcId=bc-c30a6d2b-73c9-4192-a63e-a22798d9fc30">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c30a6d2b-73c9-4192-a63e-a22798d9fc30">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

