### PR TITLE
Restyle vitepress docs to hand-drawn notebook theme

### DIFF
--- a/packages/wx-md/docs/.vitepress/config.ts
+++ b/packages/wx-md/docs/.vitepress/config.ts
@@ -8,17 +8,22 @@ export default defineConfig({
   cleanUrls: true,
   themeConfig: {
     nav: [
-      { text: '指南', link: '/guide/getting-started' },
-      { text: 'CLI', link: '/guide/cli' },
-      { text: 'API', link: '/guide/api' },
-      { text: '主题', link: '/guide/themes' },
-      { text: 'FAQ', link: '/faq' },
+      {
+        text: '文档',
+        items: [
+          { text: '📘 指南', link: '/guide/getting-started' },
+          { text: '🛠️ CLI', link: '/guide/cli' },
+          { text: '🧩 API', link: '/guide/api' },
+          { text: '🎨 主题', link: '/guide/themes' },
+          { text: '❓ FAQ', link: '/faq' }
+        ]
+      },
       { text: 'GitHub', link: 'https://github.com/cnych/markdown-weixin' }
     ],
     sidebar: {
       '/guide/': [
         {
-          text: '指南',
+          text: '📘 指南',
           items: [
             { text: '快速开始', link: '/guide/getting-started' },
             { text: '命令行 CLI', link: '/guide/cli' },
@@ -29,7 +34,7 @@ export default defineConfig({
       ],
       '/': [
         {
-          text: '文档',
+          text: '🗂️ 文档',
           items: [
             { text: '快速开始', link: '/guide/getting-started' },
             { text: 'FAQ', link: '/faq' }

--- a/packages/wx-md/docs/.vitepress/theme/components/NotebookDecor.vue
+++ b/packages/wx-md/docs/.vitepress/theme/components/NotebookDecor.vue
@@ -23,15 +23,17 @@
   z-index: 0;
 }
 
+/* Keep the red margin a bit inside to coexist with the sidebar */
 .notebook-decor__red-margin {
   position: absolute;
   top: 0;
   bottom: 0;
-  left: 72px;
+  left: 72px; /* aligns with typical content gutter */
   width: 2px;
-  background: rgba(252, 165, 165, 0.6);
+  background: var(--margin-red);
 }
 
+/* 8 punched holes */
 .notebook-decor__holes {
   position: absolute;
   left: 24px;
@@ -52,6 +54,7 @@
   margin: 12px 0;
 }
 
+/* A small doodle for the hand-drawn vibe */
 .notebook-decor__doodle {
   position: absolute;
   right: 24px;

--- a/packages/wx-md/docs/.vitepress/theme/styles.css
+++ b/packages/wx-md/docs/.vitepress/theme/styles.css
@@ -80,3 +80,129 @@ body::before {
     border-radius: 10px;
   }
 }
+
+/*****************************************
+ Notebook-styled Navbar
+*****************************************/
+.VPNav {
+  background: transparent !important;
+  box-shadow: none !important;
+}
+.VPNavBar {
+  backdrop-filter: blur(0px);
+}
+.VPNavBarTitle .title {
+  color: var(--ink) !important;
+  background: #fff;
+  border: 1px solid var(--card-border);
+  border-radius: 8px;
+  padding: 6px 10px;
+  box-shadow: 2px 2px 0 rgba(0,0,0,0.06);
+}
+.VPNavBar .content .menu .item > a,
+.VPNavBarMenu .menu .item > a,
+.VPNavBarLinks .link {
+  color: var(--ink) !important;
+  border-radius: 8px;
+  padding: 6px 10px;
+  transition: background-color .15s ease, box-shadow .15s ease, transform .05s ease;
+}
+.VPNavBar .content .menu .item > a:hover,
+.VPNavBarMenu .menu .item > a:hover,
+.VPNavBarLinks .link:hover {
+  background: #ffffff;
+  box-shadow: 2px 2px 0 rgba(0,0,0,0.06);
+}
+.VPNavBar .content .menu .item > a.active,
+.VPNavBarMenu .menu .item > a.active {
+  background: #ffffff;
+  border: 1px dashed var(--card-border);
+}
+
+/* DocSearch button styled like a small sticky tab */
+.DocSearch-Button {
+  color: var(--ink) !important;
+  background: #fff !important;
+  border: 1px solid var(--card-border) !important;
+  border-radius: 10px !important;
+  box-shadow: 2px 2px 0 rgba(0,0,0,0.06) !important;
+}
+
+/*****************************************
+ Notebook-styled Sidebar
+*****************************************/
+.VPSidebar {
+  background: transparent !important;
+  border-right: 0 !important;
+}
+.VPSidebar .group {
+  margin: 10px 8px;
+  padding: 12px 10px;
+  background: #ffffff;
+  border: 1px solid var(--card-border);
+  border-radius: 12px;
+  box-shadow: 2px 2px 0 rgba(0,0,0,0.06);
+}
+.VPSidebar .group .title {
+  color: var(--ink) !important;
+  font-weight: 700;
+}
+.VPSidebar .group .items .item .link,
+.VPSidebarItem .link,
+.VPSidebarItem .text {
+  color: var(--ink) !important;
+}
+.VPSidebar a {
+  color: var(--ink) !important;
+  border-radius: 8px;
+  padding: 6px 8px;
+}
+.VPSidebar a:hover {
+  background: #ffffff;
+  box-shadow: 2px 2px 0 rgba(0,0,0,0.05);
+}
+.VPSidebar .is-active > a,
+.VPSidebar a.active {
+  background: #ffffff;
+  border: 1px dashed var(--card-border);
+}
+
+/*****************************************
+ Homepage and cards
+*****************************************/
+.VPHome .VPHero,
+.VPHome .VPHomeFeatures .item,
+.VPDoc .custom-block,
+.VPDoc .tip,
+.VPDoc .warning {
+  background: #ffffff;
+  border: 1px solid var(--card-border);
+  border-radius: 12px;
+  box-shadow: 2px 2px 0 rgba(0,0,0,0.06);
+}
+
+/*****************************************
+ Layout spacing to account for holes and margin line
+*****************************************/
+@media (min-width: 960px) {
+  .VPContent.has-sidebar {
+    padding-left: 8px; /* small nudge so content card clears holes */
+  }
+}
+
+/*****************************************
+ Fine-tune links and hr to match ink
+*****************************************/
+.vp-doc hr {
+  border-color: var(--card-border);
+}
+.vp-doc strong, .vp-doc b {
+  color: var(--ink);
+}
+
+/*****************************************
+ Code block tone tweaks
+*****************************************/
+.vp-doc pre code {
+  color: var(--ink);
+}


### PR DESCRIPTION
Implement hand-drawn notebook theme for VitePress documentation, including redesigned navigation and visual elements.

---
<a href="https://cursor.com/background-agent?bcId=bc-6f5e085e-4200-49e1-be19-0679efebad5c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6f5e085e-4200-49e1-be19-0679efebad5c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

